### PR TITLE
TA-348: Added final fixes

### DIFF
--- a/ui/sections/forms/lineform/LineForm.tsx
+++ b/ui/sections/forms/lineform/LineForm.tsx
@@ -169,38 +169,54 @@ function LineForm({
         />
         {routePoints.length > 0 ?
           (
-            <LineEditMap
-              stops={stops}
-              routePoints={routePoints}
-              onRoutePointsUpdate={handleRoutePointsUpdate}
-            />
+            <div>
+              <LineEditMap
+                stops={stops}
+                routePoints={routePoints}
+                onRoutePointsUpdate={handleRoutePointsUpdate}
+              />
+              <Typography variant={"note"}>
+                Haz click derecho en cualquier lugar del mapa para colocar un punto de
+                la ruta.
+              </Typography>
+              <Typography variant={"note"}>
+                Para mover cualquier punto, arrastralo hacia una nueva posicion.
+              </Typography>
+              <Typography variant={"note"}>
+                Si arrastras un punto encima de una parada, este cambiara de color,
+                indicando que esta es una parada del recorrido.
+              </Typography>
+              <Typography variant={"note"}>
+                Si arrastras los puntos grises entre dos puntos ya creados, podras
+                añadir bifurcaciones a tu ruta
+              </Typography>
+              <Typography variant={"note"}>
+                Para eliminar el ultimo punto de la ruta, has Shift+D
+              </Typography>
+            </div>
           ) :
           (
-            <NewLineEditMap
-              stops={stops}
-              initialFeatureCollection={route}
-              onFeatureCollectionUpdate={handleFeatureCollectionUpdate}
-            />
+            <div>
+              <NewLineEditMap
+                stops={stops}
+                initialFeatureCollection={route}
+                onFeatureCollectionUpdate={handleFeatureCollectionUpdate}
+              />
+              <Typography variant={"note"}>
+                Da click en una parada para comenzar el recorrido. Si se tiene mas de una parada señalada, dar click añade una nueva seccion a la linea.
+              </Typography>
+              <Typography variant={"note"}>
+                Puedes seleccionar cualquier seccion entre 2 paradas para jalar y agregar un anclaje a la linea.
+              </Typography>
+              <Typography variant={"note"}>
+                Para mover un anclaje, solo arrastralo a una nueva posicion. Has doble click en un anclaje para eliminarlo de la ruta.
+              </Typography>
+              <Typography variant={"note"}>
+                Presiona Shift+D para deshacer la ultima accion realizada.
+              </Typography>
+            </div>
           )
         }
-        <Typography variant={"note"}>
-          Haz click derecho en cualquier lugar del mapa para colocar un punto de
-          la ruta.
-        </Typography>
-        <Typography variant={"note"}>
-          Para mover cualquier punto, arrastralo hacia una nueva posicion.
-        </Typography>
-        <Typography variant={"note"}>
-          Si arrastras un punto encima de una parada, este cambiara de color,
-          indicando que esta es una parada del recorrido.
-        </Typography>
-        <Typography variant={"note"}>
-          Si arrastras los puntos grises entre dos puntos ya creados, podras
-          añadir bifurcaciones a tu ruta
-        </Typography>
-        <Typography variant={"note"}>
-          Para eliminar el ultimo punto de la ruta, has Shift+D
-        </Typography>
       </div>
       <div aria-live="polite" aria-atomic="true">
         {state.message

--- a/ui/sections/maps/lineeditmap/NewLineEditMap.tsx
+++ b/ui/sections/maps/lineeditmap/NewLineEditMap.tsx
@@ -12,7 +12,6 @@ import { GeoJSONSource, MapMouseEvent } from "mapbox-gl";
 import Image from "next/image";
 import { useLineEditor } from "./useLineEditor";
 import { getGeometry } from "@/utils/mapbox/getGeometry";
-import { number } from "zod";
 
 type HoverMarker = {
   sectionId: string | number | undefined,
@@ -108,8 +107,10 @@ function NewLineEditMap({
   
     if (startStop && !endStop) {
       if (startStop.id === stop.id) return;
-  
-      const geometry = await getGeometry({ startStop, endStop: stop});
+
+      const firstPoint = positionToGeoPosition(startStop.position)
+      const secondPoint = positionToGeoPosition(stop.position)
+      const geometry = await getGeometry({ startPoint: firstPoint, endPoint: secondPoint});
       if (geometry) updateLastFeature({ endStop: stop, geometry});
       return;
     }
@@ -117,7 +118,9 @@ function NewLineEditMap({
     if (endStop?.id === stop.id) return;
   
     if(endStop) {
-      const geometry = await getGeometry({startStop: endStop, endStop: stop})
+      const firstPoint = lastFeature.geometry.coordinates.at(-1)!!
+      const secondPoint = positionToGeoPosition(stop.position)
+      const geometry = await getGeometry({startPoint: firstPoint, endPoint: secondPoint})
       if (geometry) addFeature({startStop: endStop, endStop: stop, geometry });
     }
   };
@@ -220,8 +223,8 @@ function NewLineEditMap({
     ];
 
     const geometry = await getGeometry({ 
-      startStop: marker.properties.startStop!, 
-      endStop: marker.properties.endStop!, 
+      startPoint: positionToGeoPosition(marker.properties.startStop!.position),
+      endPoint: positionToGeoPosition(marker.properties.endStop!.position),
       anchors: updatedAnchors
     })
 
@@ -237,7 +240,11 @@ function NewLineEditMap({
       index == anchorIndex ? newPosition : anchor
     )
 
-    const geometry = await getGeometry({ startStop: feature.properties.startStop!, endStop: feature.properties.endStop!, anchors: updatedAnchors })
+    const geometry = await getGeometry({ 
+      startPoint: positionToGeoPosition(feature.properties.startStop!.position),
+      endPoint: positionToGeoPosition(feature.properties.endStop!.position),
+      anchors: updatedAnchors 
+    })
     if (geometry) updateFeatureAtIndex({selectedIndex: featureIndex, anchors: updatedAnchors!, geometry: geometry})
   };
 
@@ -250,7 +257,11 @@ function NewLineEditMap({
       index !== anchorIndex
     )
 
-    const geometry = await getGeometry({ startStop: feature.properties.startStop!, endStop: feature.properties.endStop!, anchors: updatedAnchors })
+    const geometry = await getGeometry({
+      startPoint: positionToGeoPosition(feature.properties.startStop!.position),
+      endPoint: positionToGeoPosition(feature.properties.endStop!.position),
+      anchors: updatedAnchors
+    })
     if (geometry) updateFeatureAtIndex({selectedIndex: featureIndex, anchors: updatedAnchors!, geometry: geometry})
   };
 

--- a/ui/sections/maps/lineeditmap/useLineEditor.ts
+++ b/ui/sections/maps/lineeditmap/useLineEditor.ts
@@ -1,6 +1,6 @@
 import { LineSection, Stop } from "@/app/lib/definitions";
 import { Feature, FeatureCollection, LineString, Position } from "geojson";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 type AddFeatureParams = {
   startStop: Stop;


### PR DESCRIPTION
## Description
We need to add the following:
- [x]  Instructions: We should show a dialog that describes the instructions on how to use the line map.
- [x]  Consistent line sections: Sometimes line sections are not consistent due to stop point being close to a secondary street. We need to change logic so next section uses the previous geometry last point as the start point for the API call (we still store stops in properties).
- [x]  Overview polyline: When we save the line, we need to store a overview polyline, to be used in the previews in admin and normal app. We also should highlight the stops related to that line (created a relation table)